### PR TITLE
User ID validation + early release processing status + some other fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@
 Changes
 =======
 
-Version 0.0.1 (release 2026-04-01)
+Version 0.1.0 (released 2026-05-18)
+
+- feat(tasks): mark release task as `PROCESSING` before generic method
+- fix(webhook): add user ID validation
+- fix(access): add `any_user` permission when extracting `self.user_identity`
+- fix(tasks): use correct type (`RemoteToken` class) during `disconnect_provider` task
+- feat(providers): support filtering repo visibility for GH/GL
+- fix(gitlab): ignore missing default branches
+
+Version 0.0.1 (released 2026-04-01)
 
 - initial release

--- a/invenio_vcs/__init__.py
+++ b/invenio_vcs/__init__.py
@@ -9,6 +9,6 @@
 
 from .ext import InvenioVCS
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 __all__ = ("__version__", "InvenioVCS")

--- a/invenio_vcs/alembic/1754318294_switch_to_generic_git_services.py
+++ b/invenio_vcs/alembic/1754318294_switch_to_generic_git_services.py
@@ -16,7 +16,9 @@ from sqlalchemy_utils import JSONType, UUIDType
 revision = "1754318294"
 down_revision = "6abc1c58775e"
 branch_labels = ()
-depends_on = None
+# Depends on Invenio-Webhooks for foreign key reference
+# See https://github.com/inveniosoftware/invenio-webhooks/blob/9eda483685fac20d28d0036218aa178ce5bb2879/invenio_webhooks/alembic/a095bd179f5c_create_webhooks_tables.py#L32
+depends_on = "a095bd179f5c"
 
 
 def upgrade():

--- a/invenio_vcs/api.py
+++ b/invenio_vcs/api.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from flask import current_app
-from invenio_access.permissions import authenticated_user
+from invenio_access.permissions import any_user, authenticated_user
 from invenio_access.utils import get_identity
 from werkzeug.utils import cached_property
 
@@ -95,6 +95,7 @@ class VCSRelease:
         """Generates release owner's user identity."""
         identity = get_identity(self.db_repo.enabled_by_user)
         identity.provides.add(authenticated_user)
+        identity.provides.add(any_user)
         identity.user = self.db_repo.enabled_by_user
         return identity
 

--- a/invenio_vcs/contrib/github.py
+++ b/invenio_vcs/contrib/github.py
@@ -69,6 +69,9 @@ class GitHubProviderFactory(RepositoryServiceProviderFactory):
         self._github_specific_config.update(
             shared_secret="",
             insecure_ssl=False,
+            # Corresponds to the `type` parameter here: https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-repositories-for-the-authenticated-user.
+            # Set this to `public` to only sync the public repos that a user has access to.
+            allowed_repository_type="all",
         )
         self._github_specific_config.update(config)
 
@@ -225,7 +228,9 @@ class GitHubProvider(RepositoryServiceProvider):
     def list_repositories(self):
         """List the user's top repos."""
         repos: dict[str, GenericRepository] = {}
-        for repo in self._github.repositories():
+        for repo in self._github.repositories(
+            type=self.factory.provider_specific_config.get("allowed_repository_type")
+        ):
             assert isinstance(repo, ShortRepository)
 
             if repo.permissions["admin"]:

--- a/invenio_vcs/contrib/gitlab.py
+++ b/invenio_vcs/contrib/gitlab.py
@@ -288,10 +288,17 @@ class GitLabProvider(RepositoryServiceProvider):
             )
 
         for project in itertools.chain(*iters):
+            default_branch = getattr(project, "default_branch", None)
+            if default_branch is None:
+                # For projects without a repository (i.e. a file tree), the `default_branch` attribute is not returned
+                # in the API response. These projects inherently cannot contain releases so they cannot be synced to
+                # InvenioRDM. We therefore exclude them from the list.
+                continue
+
             repos[str(project.id)] = GenericRepository(
                 id=str(project.id),
                 full_name=project.path_with_namespace,
-                default_branch=project.default_branch,
+                default_branch=default_branch,
                 description=project.description,
                 # The license is not returned in the project list, and it is not needed here.
                 license_spdx=None,

--- a/invenio_vcs/contrib/gitlab.py
+++ b/invenio_vcs/contrib/gitlab.py
@@ -11,7 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+import itertools
+from typing import TYPE_CHECKING, Any
 
 import dateutil
 import gitlab
@@ -36,6 +37,10 @@ from invenio_vcs.providers import (
     RepositoryServiceProvider,
     RepositoryServiceProviderFactory,
 )
+
+if TYPE_CHECKING:
+    from gitlab.base import RESTObjectList
+    from gitlab.v4.objects.projects import Project
 
 
 def _gitlab_response_error_handler(f):
@@ -93,7 +98,11 @@ class GitLabProviderFactory(RepositoryServiceProviderFactory):
         )
 
         self._gitlab_specific_config = dict()
-        self._gitlab_specific_config.update(shared_validation_token="")
+        self._gitlab_specific_config.update(
+            shared_validation_token="",
+            # Only sync projects with one of these visibilities.
+            allowed_project_visibilities=["private", "internal", "public"],
+        )
         self._gitlab_specific_config.update(config)
 
     def update_config_with_override(self, config_override: dict):
@@ -260,11 +269,25 @@ class GitLabProvider(RepositoryServiceProvider):
     def list_repositories(self) -> dict[str, GenericRepository] | None:
         """List all projects."""
         repos: dict[str, GenericRepository] = {}
-        for project in self._gitlab.projects.list(
-            iterator=True,
-            simple=False,
-            min_access_level=gitlab.const.MAINTAINER_ACCESS,
+
+        # `visibility` only allows one value; you cannot query e.g. 'internal OR public'.
+        # So we create one iterator for each allowed visibility and then chain them together.
+        # This doesn't have a particularly large performance impact since each project will
+        # still only be returned once.
+        iters: list[RESTObjectList[Project]] = []
+        for visibility in self.factory.provider_specific_config.get(
+            "allowed_project_visibilities", []
         ):
+            iters.append(
+                self._gitlab.projects.list(
+                    iterator=True,
+                    simple=False,
+                    min_access_level=gitlab.const.MAINTAINER_ACCESS,
+                    visibility=visibility,
+                )
+            )
+
+        for project in itertools.chain(*iters):
             repos[str(project.id)] = GenericRepository(
                 id=str(project.id),
                 full_name=project.path_with_namespace,

--- a/invenio_vcs/receivers.py
+++ b/invenio_vcs/receivers.py
@@ -8,6 +8,7 @@
 """Task for managing vcs integration."""
 
 from invenio_db import db
+from invenio_webhooks.models import Event as WebhookEvent
 from invenio_webhooks.models import Receiver
 
 from invenio_vcs.config import get_provider_by_id
@@ -31,7 +32,7 @@ class VCSReceiver(Receiver):
         super().__init__(receiver_id)
         self.provider_factory = get_provider_by_id(receiver_id)
 
-    def run(self, event):
+    def run(self, event: WebhookEvent):
         """Process an event.
 
         .. note::
@@ -42,7 +43,7 @@ class VCSReceiver(Receiver):
         """
         self._handle_event(event)
 
-    def _handle_event(self, event):
+    def _handle_event(self, event: WebhookEvent):
         """Handles an incoming vcs event."""
         is_create_release_event = self.provider_factory.webhook_is_create_release_event(
             event.payload
@@ -56,7 +57,7 @@ class VCSReceiver(Receiver):
             # to only be delivered for the exact event we need.
             pass
 
-    def _handle_create_release(self, event):
+    def _handle_create_release(self, event: WebhookEvent):
         """Creates a release in invenio."""
         try:
             generic_release = self.provider_factory.webhook_event_to_generic_release(
@@ -77,8 +78,14 @@ class VCSReceiver(Receiver):
                 self.provider_factory.id,
                 provider_id=generic_release.repository_id,
             )
+
             if not repo:
                 raise RepositoryNotFoundError(generic_release.repository_id)
+
+            if repo.enabled_by_user_id != event.user_id:
+                # Ensure the webhook URL contained the access token of the user who created the webhook (i.e. enabled the repository).
+                # Therefore, we ensure the webhook call contains the data of a repository/release that belongs to the user.
+                raise InvalidSenderError(event.id, event.user.id)
 
             if repo.enabled:
                 release = Release(

--- a/invenio_vcs/tasks.py
+++ b/invenio_vcs/tasks.py
@@ -138,6 +138,12 @@ def process_release(provider, release_id):
     )
     release = current_vcs.release_api_class(release_model, provider)
 
+    # Mark the release as processing so users can see the status in case
+    # `process_release` is a long-running method. We need to commit so the
+    # status is visible to the user before the full task finishes.
+    release_model.status = ReleaseStatus.PROCESSING
+    db.session.commit()
+
     matched_error_cls = None
     matched_ex = None
 

--- a/invenio_vcs/tasks.py
+++ b/invenio_vcs/tasks.py
@@ -16,7 +16,7 @@ from celery import shared_task
 from flask import current_app, g
 from invenio_db import db
 from invenio_i18n import gettext as _
-from invenio_oauthclient.models import RemoteAccount
+from invenio_oauthclient.models import RemoteAccount, RemoteToken
 from invenio_oauthclient.proxies import current_oauthclient
 
 from invenio_vcs.config import get_provider_by_id
@@ -61,7 +61,13 @@ def disconnect_provider(provider_id, user_id, access_token, repo_hooks):
     try:
         # Create a nested transaction to make sure that hook deletion + token revoke is atomic
         with db.session.begin_nested():
-            svc = VCSService.for_provider_and_token(provider_id, user_id, access_token)
+            remote_token = RemoteToken.get_by_token(provider_id, access_token)
+            assert remote_token is not None
+
+            if remote_token.is_expired:
+                remote_token.refresh_access_token()
+
+            svc = VCSService.for_provider_and_token(provider_id, user_id, remote_token)
 
             for repo_id, repo_hook in repo_hooks:
                 if svc.disable_repository(repo_id, repo_hook):


### PR DESCRIPTION
- Added user ID validation during the webhook receiver to ensure the access token belongs to the user who enabled the repo
  - The `InvalidSenderError` was already there but we weren't using anywhere, including in `invenio-rdm-records`.
- Added a step to the release task to mark the release as "processing" and commit the change before we actually call the process method, since the task can sometimes be quite long running and the user should be able to see that it has started.