### PR TITLE
fix(ui): correct menu item ordering

### DIFF
--- a/invenio_vcs/ext.py
+++ b/invenio_vcs/ext.py
@@ -87,7 +87,7 @@ def finalize_app_api(app):
 
 def init_menu(app):
     """Init menu."""
-    for provider in get_provider_list(app):
+    for index, provider in enumerate(get_provider_list(app)):
 
         def is_active(current_node):
             return (
@@ -105,7 +105,8 @@ def init_menu(app):
                 ),
                 provider=provider.name,
             ),
-            order=10,
+            # See https://github.com/inveniosoftware/invenio-app-rdm/issues/3432#issuecomment-4459637019
+            order=10 + index,
             active_when=is_active,
         )
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3432

---

See https://github.com/inveniosoftware/invenio-app-rdm/issues/3432#issuecomment-4459637019 for the proposed ordering of menu items.

This technically means you cannot have more than 10 VCS providers without buggy menu behaviour, but I think this is acceptable.