### PR TITLE
perf(models): index release repository_id and repo-user user_id

### DIFF
--- a/invenio_vcs/alembic/1784109600_add_repo_listing_fk_indexes.py
+++ b/invenio_vcs/alembic/1784109600_add_repo_listing_fk_indexes.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Add indexes on Release.repository_id and repository_user_association.user_id."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1784109600"
+down_revision = "1777230124"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_index(
+        op.f("ix_vcs_releases_repository_id"),
+        table_name="vcs_releases",
+        columns=["repository_id"],
+    )
+    op.create_index(
+        op.f("ix_vcs_repository_users_user_id"),
+        table_name="vcs_repository_users",
+        columns=["user_id"],
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_index(
+        op.f("ix_vcs_repository_users_user_id"),
+        table_name="vcs_repository_users",
+    )
+    op.drop_index(
+        op.f("ix_vcs_releases_repository_id"),
+        table_name="vcs_releases",
+    )

--- a/invenio_vcs/models.py
+++ b/invenio_vcs/models.py
@@ -72,7 +72,11 @@ repository_user_association = db.Table(
         primary_key=True,
     ),
     db.Column(
-        "user_id", db.Integer, db.ForeignKey("accounts_user.id"), primary_key=True
+        "user_id",
+        db.Integer,
+        db.ForeignKey("accounts_user.id"),
+        primary_key=True,
+        index=True,
     ),
     db.Column("created", UTCDateTime, nullable=False),
     db.Column("updated", UTCDateTime, nullable=False),
@@ -269,7 +273,7 @@ class Release(db.Model, Timestamp):
     )
     """Release processing errors."""
 
-    repository_id = db.Column(UUIDType, db.ForeignKey(Repository.id))
+    repository_id = db.Column(UUIDType, db.ForeignKey(Repository.id), index=True)
     """Repository identifier."""
 
     event_id = db.Column(UUIDType, db.ForeignKey(Event.id), nullable=True)


### PR DESCRIPTION
* Index `vcs_releases.repository_id`: listing a user's repositories
  looks up the latest release per repository, which scanned the whole
  releases table on each lookup. This is the main cause of the
  settings page timing out for users with many repositories.
* Index `vcs_repository_users.user_id`: the composite primary key
  leads with `repository_id`, so a filter on `user_id` alone (used
  when listing a user's repositories) could not use it.
